### PR TITLE
feat(undo): Wire up undo/redo feature for end users

### DIFF
--- a/Sources/SortAI/App/ContentView.swift
+++ b/Sources/SortAI/App/ContentView.swift
@@ -310,6 +310,43 @@ struct ContentView: View {
             // Model & Pipeline Status
             modelStatusIndicator
             
+            // Undo/Redo buttons (when operations available)
+            if appState.canUndoLastMove || appState.canRedoLastMove {
+                HStack(spacing: 4) {
+                    Button {
+                        Task { await appState.undoLastMove() }
+                    } label: {
+                        Image(systemName: "arrow.uturn.backward")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(appState.canUndoLastMove ? .primary : .tertiary)
+                    .disabled(!appState.canUndoLastMove)
+                    .help("Undo last file move (⌘Z)")
+                    .keyboardShortcut("z", modifiers: .command)
+                    
+                    Button {
+                        Task { await appState.redoLastMove() }
+                    } label: {
+                        Image(systemName: "arrow.uturn.forward")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(appState.canRedoLastMove ? .primary : .tertiary)
+                    .disabled(!appState.canRedoLastMove)
+                    .help("Redo last undone move (⇧⌘Z)")
+                    .keyboardShortcut("z", modifiers: [.command, .shift])
+                    
+                    if appState.undoableOperationsCount > 0 {
+                        Text("\(appState.undoableOperationsCount)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color.secondary.opacity(0.1))
+                .cornerRadius(4)
+            }
+            
             // Stats
             if appState.totalProcessed > 0 {
                 HStack(spacing: 12) {


### PR DESCRIPTION
## Summary

Wires up the existing SafeFileOrganizer/UndoStack/MovementLog infrastructure to the UI, making undo available to end users.

## Changes

### AppState.swift
- Replace `FileOrganizer` with `SafeFileOrganizer` for file organization
- Initialize `UndoStack` with 100 operation limit on app startup
- Add `canUndoLastMove`/`canRedoLastMove`/`undoableOperationsCount` state tracking
- Add `undoLastMove()` and `redoLastMove()` async methods
- Add `updateUndoState()` helper to sync UI with undo stack

### ContentView.swift
- Add undo/redo buttons to footer view
- Add keyboard shortcuts (⌘Z for undo, ⇧⌘Z for redo)
- Show undoable operations count when available
- Buttons auto-hide when no undo/redo operations available

## Addresses Spec Requirements

From `spec.md`:
- **Section 1.1**: "Trust: Full transparency, preview-before-move, and robust undo"
- **Section 3 UX**: "Visible undo/redo affordances near move/organize actions"
- **Section 4.3**: "Soft Move Option... Fully undoable"
- **Section 6.3**: "Undo System - File-level or batch-level undo"

## Testing

- [x] Build passes (all 265 compilation units)
- [x] All 257 tests pass
- [x] Manual testing: Undo buttons appear in footer after file organization
- [x] Keyboard shortcuts registered

## Screenshots

N/A - functional UI addition with minimal visual change (small undo/redo icons in footer)

## Migration Notes

None - This is an additive change. The `SafeFileOrganizer` is now used instead of `FileOrganizer`, but the fallback to `FileOrganizer` is preserved if the safe organizer fails to initialize.